### PR TITLE
Fix eccodes for tests 

### DIFF
--- a/grib2data/CMakeLists.txt
+++ b/grib2data/CMakeLists.txt
@@ -24,5 +24,5 @@ file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests_results/grib2data/)
 foreach( f ${LIST_TESTS})
 
 add_test(NAME ${f}
-    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test.sh ${f} ${LFITOOLS} ${CMAKE_CURRENT_SOURCE_DIR} ${ECCODES_LIB_DIR} ${CMAKE_BINARY_DIR})
+	COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test.sh ${f} ${LFITOOLS} ${CMAKE_CURRENT_SOURCE_DIR} ${eccodes_ROOT} ${CMAKE_BINARY_DIR})
 endforeach()

--- a/grib2data/test.sh
+++ b/grib2data/test.sh
@@ -27,7 +27,6 @@ unset ECCODES_DEFINITION_PATH
 unset GRIB_DEFINITION_PATH
 unset ECCODES_SAMPLES_PATH
 unset GRIB_SAMPLE_PATH 
-grib_api_prefix=$(dirname $grib_api_prefix)
 
 ## ECCODES_DEFINITION_PATH and ECCODES_SAMPLES_PATH aren't needed
 #export ECCODES_DEFINITION_PATH=$p/extra_grib_defs:$grib_api_prefix/share/definitions:$grib_api_prefix/share/eccodes/definitions

--- a/grib2meta/CMakeLists.txt
+++ b/grib2meta/CMakeLists.txt
@@ -24,5 +24,5 @@ file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/tests_results/grib2meta/)
 foreach( f ${LIST_TESTS})
 
 add_test(NAME ${f}
-    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test.sh ${f} ${LFITOOLS} ${CMAKE_CURRENT_SOURCE_DIR} ${ECCODES_LIB_DIR} ${CMAKE_BINARY_DIR})
+	COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test.sh ${f} ${LFITOOLS} ${CMAKE_CURRENT_SOURCE_DIR} ${eccodes_ROOT} ${CMAKE_BINARY_DIR})
 endforeach()

--- a/grib2meta/test.sh
+++ b/grib2meta/test.sh
@@ -27,7 +27,6 @@ unset ECCODES_DEFINITION_PATH
 unset GRIB_DEFINITION_PATH
 unset ECCODES_SAMPLES_PATH
 unset GRIB_SAMPLE_PATH 
-grib_api_prefix=$(dirname $grib_api_prefix)
 
 export ECCODES_DEFINITION_PATH=$p/extra_grib_defs
 ## ECCODES_SAMPLES_PATH isn't needed

--- a/test_lfa.py
+++ b/test_lfa.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+"""
+Test the LFA low level python API
+"""
+
+import tempfile
+import numpy
+from falfilfa4py import LFA
+
+data = {'float': numpy.arange(20, dtype=numpy.float64),
+        'int': numpy.arange(25, dtype=numpy.int64),
+        'char': numpy.array(['string', 'longlongstring'])
+        }
+
+LFA_MAX_NUM_FIELDS = 10
+LFA_MAXSTRLEN = 20
+
+with tempfile.NamedTemporaryFile() as f:
+
+    #######################
+    # Write test
+
+    # open
+    unit = LFA.wlfaouv(f.name, 'W')
+
+    # write float
+    LFA.wlfaecrr(unit, 'float', data['float'], len(data['float']))
+
+    # write int
+    LFA.wlfaecri(unit, 'int', data['int'], len(data['int']))
+
+    # write char
+    LFA.wlfaecrc(unit, 'char', data['char'], len(data['char']))
+
+    # close
+    LFA.wlfafer(unit)
+
+    #######################
+    # Read test
+
+    # test and open
+    assert LFA.wlfatest(f.name)
+    unit = LFA.wlfaouv(f.name, 'R')
+
+    # field list
+    list_length, fieldslist = LFA.wlfalaft(unit,
+                                           LFA_MAX_NUM_FIELDS,
+                                           LFA_MAXSTRLEN)
+    fieldslist = [fieldslist[i].strip().decode() for i in range(list_length)]
+    assert list_length == len(data) and \
+           all(k in fieldslist for k in data)
+
+    # read float
+    fieldtype, fieldlength = LFA.wlfacas(unit, 'float')
+    assert fieldtype[0] == 'R' and fieldlength == len(data['float'])
+    readdata, fieldlength = LFA.wlfalecr(unit, 'float', fieldlength)
+    assert numpy.all(readdata == data['float']) and \
+           fieldlength == len(data['float'])
+
+    # read int
+    fieldtype, fieldlength = LFA.wlfacas(unit, 'int')
+    assert fieldtype[0] == 'I' and fieldlength == len(data['int'])
+    readdata, fieldlength = LFA.wlfaleci(unit, 'int', fieldlength)
+    assert numpy.all(readdata == data['int']) and \
+           fieldlength == len(data['int'])
+
+    # read char
+    fieldtype, fieldlength = LFA.wlfacas(unit, 'char')
+    assert fieldtype[0] == 'C' and fieldlength == len(data['char'])
+    strlen = max(len(s) for s in data['char'])
+    readdata, fieldlength = LFA.wlfalecc(unit, 'char', fieldlength, strlen)
+    readdata = numpy.array([s.decode('utf-8') for s in readdata])
+    assert numpy.all(readdata == data['char']) and \
+           fieldlength == len(data['char'])
+
+    # close
+    LFA.wlfafer(unit)


### PR DESCRIPTION
assuming commit a93dbfc76 of FALFILFA has been integrated (definition of `eccodes_ROOT` at compile time)